### PR TITLE
Log chess notation

### DIFF
--- a/lib/chessmate.rb
+++ b/lib/chessmate.rb
@@ -33,7 +33,7 @@ class ChessMate
                  ignore_logging: false)
     @board = board || DEFAULT[:board].map(&:dup)
     @turn = turn || DEFAULT[:turn]
-    @promotable = promotable 
+    @promotable = promotable
     @en_passant = en_passant || DeepDup.deep_dup(DEFAULT[:en_passant])
     @castling = castling || DeepDup.deep_dup(DEFAULT[:castling])
     @in_check = in_check || DeepDup.deep_dup(DEFAULT[:in_check])
@@ -89,9 +89,9 @@ class ChessMate
       @board[orig_y][new_rook_x_position] = piece_type[0] + 'R'
     end
 
-    @promotable = dest if piece_type[1] == "P" && promote?(orig)
+    @promotable = dest if piece_type[1] == 'P' && promote?(orig)
 
-    if !@ignore_logging
+    unless @ignore_logging
       logger = Logger.new(orig, dest, @board)
       @move_history << logger.log_move
     end
@@ -277,9 +277,9 @@ class ChessMate
 
     @board[square_y][square_x] = old_piece[0] + piece_type
 
-    if !@ignore_logging
-      logger = Logger.new(nil, nil, nil, promotion_type: piece_type, history: @move_history)
-      @move_history[-1] += logger.log_promotion
-    end
+    return if @ignore_logging
+
+    logger = Logger.new(nil, nil, nil, promotion_type: piece_type, history: @move_history)
+    @move_history[-1] += logger.log_promotion
   end
 end

--- a/lib/chessmate.rb
+++ b/lib/chessmate.rb
@@ -91,7 +91,7 @@ class ChessMate
 
     @promotable = dest if piece_type[1] == "P" && promote?(orig)
 
-    if !@ignore_logging && !@promotable
+    if !@ignore_logging
       logger = Logger.new(orig, dest, @board)
       @move_history << logger.log_move
     end
@@ -276,5 +276,10 @@ class ChessMate
     end
 
     @board[square_y][square_x] = old_piece[0] + piece_type
+
+    if !@ignore_logging
+      logger = Logger.new(nil, nil, nil, promotion_type: piece_type, history: @move_history)
+      @move_history[-1] += logger.log_promotion
+    end
   end
 end

--- a/lib/chessmate.rb
+++ b/lib/chessmate.rb
@@ -24,15 +24,16 @@ class ChessMate
 
   def initialize(board: nil,
                  turn: nil,
-                 promotable: nil,
+                 promotable: false,
                  en_passant: nil,
                  castling: nil,
                  in_check: nil,
                  allow_out_of_turn: nil,
-                 move_history: nil)
+                 move_history: nil,
+                 ignore_logging: false)
     @board = board || DEFAULT[:board].map(&:dup)
     @turn = turn || DEFAULT[:turn]
-    @promotable = promotable || DeepDup.deep_dup(DEFAULT[:promotable])
+    @promotable = promotable 
     @en_passant = en_passant || DeepDup.deep_dup(DEFAULT[:en_passant])
     @castling = castling || DeepDup.deep_dup(DEFAULT[:castling])
     @in_check = in_check || DeepDup.deep_dup(DEFAULT[:in_check])
@@ -45,6 +46,7 @@ class ChessMate
                            false
                          end
     @move_history = move_history || []
+    @ignore_logging = ignore_logging
   end
 
   def update(orig, dest = nil)
@@ -87,13 +89,16 @@ class ChessMate
       @board[orig_y][new_rook_x_position] = piece_type[0] + 'R'
     end
 
-    logger = Logger.new(orig, dest, @board)
-    @move_history << logger.log_move
+    @promotable = dest if piece_type[1] == "P" && promote?(orig)
+
+    if !@ignore_logging && !@promotable
+      logger = Logger.new(orig, dest, @board)
+      @move_history << logger.log_move
+    end
 
     @board[orig_y][orig_x] = nil
     @board[dest_y][dest_x] = piece_type
 
-    @promotable = dest if piece_type[1] == 'P' && promote?(dest)
     @in_check = in_check?
     @turn += 1
   end
@@ -245,8 +250,8 @@ class ChessMate
   def promote?(square)
     square_y = square[0]
     square_x = square[1]
-    piece = @board[square_y][square_x][0]
-    promote_column = piece.downcase == 'w' ? 0 : 7
+    piece_color = @board[square_y][square_x][0]
+    promote_column = piece_color.downcase == 'w' ? 1 : 6
     promote_column == square_y
   end
 
@@ -255,7 +260,7 @@ class ChessMate
     square_x = square[1]
 
     old_piece = @board[square_y][square_x]
-    return nil if old_piece.nil? || !promote?(square)
+    return nil if old_piece.nil? || @promotable != [square_y, square_x]
 
     case piece.downcase
     when 'rook'

--- a/lib/helpers/default.rb
+++ b/lib/helpers/default.rb
@@ -12,7 +12,6 @@ DEFAULT = {
     %w[WR WN WB WQ WK WB WN WR]
   ],
   turn: 1,
-  promotable: nil,
   en_passant: { white: nil, black: nil },
   in_check: { white: false, black: false },
   castling: {

--- a/lib/helpers/logger.rb
+++ b/lib/helpers/logger.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'helpers/notation_parser'
+require 'pry'
+
+class Logger
+  def initialize(orig, dest, board, en_passant = false)
+    @orig = orig
+    @dest = dest
+    @board = board
+    @en_passant = en_passant
+
+    @orig_y, @orig_x = @orig
+    @dest_y, @dest_x = @dest
+
+    @piece = @board[@orig_y][@orig_x]
+
+    @piece_color, @piece_type = @piece.chars
+  end
+
+  def log_move
+    if @board[@dest_y][@dest_x] || @en_passant
+      log_capture
+    else
+      log_normal_move
+    end
+  end
+
+  private
+
+  def log_normal_move
+    notation = NotationParser.encode_notation(@dest)
+    @piece_type != 'P' ? @piece_type + notation : notation
+  end
+
+  def log_capture
+    origin_square = NotationParser.encode_notation(@orig)[0] if @piece_type == 'P'
+    origin_square ||= @piece_type
+    destination_square = NotationParser.encode_notation(@dest)
+    origin_square + 'x' + destination_square
+  end
+end

--- a/lib/helpers/logger.rb
+++ b/lib/helpers/logger.rb
@@ -2,7 +2,6 @@
 
 require 'helpers/notation_parser'
 require 'chessmate'
-require 'pry'
 
 class Logger
   def initialize(orig, dest, board, en_passant: false, promotion_type: nil, history: nil)
@@ -10,6 +9,7 @@ class Logger
     @history = history
 
     return unless orig && dest && board
+
     @orig = orig
     @dest = dest
     @board = board
@@ -33,7 +33,7 @@ class Logger
   end
 
   def log_promotion
-    @promotion_type ? "=(#{@promotion_type})" : ""
+    @promotion_type ? "=(#{@promotion_type})" : ''
   end
 
   private
@@ -76,7 +76,7 @@ class Logger
     game = ChessMate.new(board: @board, ignore_logging: true)
     encoded_orig = NotationParser.encode_notation(@orig)
     encoded_dest = NotationParser.encode_notation(@dest)
-    opposite_color_letter = @piece_color == "W" ? "B" : "W"
+    opposite_color_letter = @piece_color == 'W' ? 'B' : 'W'
     opposite_color_string = opposite_color_letter == 'W' ? 'white' : 'black'
 
     game.move(encoded_orig, encoded_dest)
@@ -85,7 +85,7 @@ class Logger
 
     return '#' if checkmate
     return '+' if check
-    
-    ""
+
+    ''
   end
 end

--- a/lib/helpers/logger.rb
+++ b/lib/helpers/logger.rb
@@ -5,20 +5,19 @@ require 'chessmate'
 require 'pry'
 
 class Logger
-  def initialize(orig, dest, board, en_passant: false, promotion_type: nil)
+  def initialize(orig, dest, board, en_passant: false, promotion_type: nil, history: nil)
+    @promotion_type = promotion_type
+    @history = history
+
+    return unless orig && dest && board
     @orig = orig
     @dest = dest
     @board = board
     @en_passant = en_passant
-
     @orig_y, @orig_x = @orig
     @dest_y, @dest_x = @dest
-
     @piece = @board[@orig_y][@orig_x]
-
     @piece_color, @piece_type = @piece.chars
-
-    @promotion_type = promotion_type
   end
 
   def log_move
@@ -30,7 +29,11 @@ class Logger
     capture = @board[@dest_y][@dest_x] || @en_passant ? 'x' : ''
     destination = NotationParser.encode_notation(@dest)
 
-    origin + capture + destination + promotion(@promotion_type) + check_or_mate
+    origin + capture + destination + check_or_mate
+  end
+
+  def log_promotion
+    @promotion_type ? "=(#{@promotion_type})" : ""
   end
 
   private
@@ -84,9 +87,5 @@ class Logger
     return '+' if check
     
     ""
-  end
-
-  def promotion(promotion_type)
-    ''
   end
 end

--- a/lib/helpers/logger.rb
+++ b/lib/helpers/logger.rb
@@ -20,6 +20,10 @@ class Logger
   end
 
   def log_move
+    if @piece_type == 'K' && (@orig_x - @dest_x).abs > 1
+      return (@dest_x - @orig_x).positive? ? '0-0' : '0-0-0'
+    end
+
     origin = encode_origin
     capture = @board[@dest_y][@dest_x] || @en_passant ? 'x' : ''
     destination = NotationParser.encode_notation(@dest)

--- a/lib/helpers/logger.rb
+++ b/lib/helpers/logger.rb
@@ -30,33 +30,19 @@ class Logger
   private
 
   def encode_origin
-    file = @board.each.map.with_index { |row, i| row[@orig_x] if i != @orig_y }
-    rank = @board[@orig_y].map.with_index { |col, i| col if i != @orig_x }
+    notation_required = [false, false]
+    game = ChessMate.new(board: @board)
+    encoded_dest = NotationParser.encode_notation(@dest)
 
-    ambiguous_in_file = file.include?(@piece)
-    ambiguous_in_rank = rank.include?(@piece)
+    @board.each_with_index do |row, y|
+      row.each_with_index do |col, x|
+        next unless @piece == col && [@orig_y, @orig_x] != [y, x]
 
-    if ambiguous_in_file || ambiguous_in_rank
-      notation_required = [false, false]
+        encoded_orig = NotationParser.encode_notation([y, x])
 
-      game = ChessMate.new(board: @board)
-      encoded_dest = NotationParser.encode_notation(@dest)
-
-      if ambiguous_in_file
-        file_ambigs = file.map.with_index { |row, i| i if row == @piece }.compact
-
-        file_ambigs.each do |y|
-          encoded_orig = NotationParser.encode_notation([y, @orig_x])
-          notation_required[1] = true if game.move(encoded_orig, encoded_dest, true)
-        end
-      end
-
-      if ambiguous_in_rank
-        rank_ambigs = rank.map.with_index { |col, i| i if col == @piece }.compact
-
-        rank_ambigs.each do |x|
-          encoded_orig = NotationParser.encode_notation([@orig_y, x])
-          notation_required[0] = true if game.move(encoded_orig, encoded_dest, true)
+        if game.move(encoded_orig, encoded_dest, true)
+          notation_required[0] = true if @orig_y == y || (@orig_y != y && @orig_x != x)
+          notation_required[1] = true if @orig_x == x
         end
       end
     end

--- a/lib/helpers/logger.rb
+++ b/lib/helpers/logger.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'helpers/notation_parser'
+require 'chessmate'
 require 'pry'
 
 class Logger
@@ -19,24 +20,62 @@ class Logger
   end
 
   def log_move
-    if @board[@dest_y][@dest_x] || @en_passant
-      log_capture
-    else
-      log_normal_move
-    end
+    origin = encode_origin
+    capture = @board[@dest_y][@dest_x] || @en_passant ? 'x' : ''
+    destination = NotationParser.encode_notation(@dest)
+
+    origin + capture + destination
   end
 
   private
 
-  def log_normal_move
-    notation = NotationParser.encode_notation(@dest)
-    @piece_type != 'P' ? @piece_type + notation : notation
-  end
+  def encode_origin
+    file = @board.each.map.with_index { |row, i| row[@orig_x] if i != @orig_y }
+    rank = @board[@orig_y].map.with_index { |col, i| col if i  != @orig_x }
 
-  def log_capture
-    origin_square = NotationParser.encode_notation(@orig)[0] if @piece_type == 'P'
-    origin_square ||= @piece_type
-    destination_square = NotationParser.encode_notation(@dest)
-    origin_square + 'x' + destination_square
+    ambiguous_in_file = file.include?(@piece)
+    ambiguous_in_rank = rank.include?(@piece)
+
+    if ambiguous_in_file || ambiguous_in_rank
+      notation_required = [false, false]
+
+      game = ChessMate.new(board: @board)
+      encoded_dest = NotationParser.encode_notation(@dest)
+
+      if ambiguous_in_file
+        file_ambigs = file.map.with_index { |row, i| i if row == @piece }.compact
+
+        file_ambigs.each do |y|
+          encoded_orig = NotationParser.encode_notation([y, @orig_x])
+          notation_required[1] = true if game.move(encoded_orig, encoded_dest, true)
+        end
+      end
+
+      if ambiguous_in_rank
+        rank_ambigs = rank.map.with_index { |col, i| i if col == @piece }.compact
+
+        rank_ambigs.each do |x|
+          encoded_orig = NotationParser.encode_notation([@orig_y, x])
+          notation_required[0] = true if game.move(encoded_orig, encoded_dest, true)
+        end
+      end
+    end
+
+    if notation_required.nil? || !notation_required.any?(true)
+      if @piece_type == "P" 
+        if ( @board[@dest_y][@dest_x] || @en_passant )
+          return NotationParser.encode_notation(@orig)[0]
+        else
+          return ''
+        end
+      end
+      return @piece_type
+    end
+    ambiguous_encoded = @piece_type
+    encoded_origin_chars  = NotationParser.encode_notation(@orig).chars
+    notation_required.each_with_index do |value, i|
+      ambiguous_encoded += encoded_origin_chars[i] if value
+    end
+    ambiguous_encoded
   end
 end

--- a/lib/helpers/logger.rb
+++ b/lib/helpers/logger.rb
@@ -31,7 +31,7 @@ class Logger
 
   def encode_origin
     file = @board.each.map.with_index { |row, i| row[@orig_x] if i != @orig_y }
-    rank = @board[@orig_y].map.with_index { |col, i| col if i  != @orig_x }
+    rank = @board[@orig_y].map.with_index { |col, i| col if i != @orig_x }
 
     ambiguous_in_file = file.include?(@piece)
     ambiguous_in_rank = rank.include?(@piece)
@@ -61,18 +61,16 @@ class Logger
       end
     end
 
-    if notation_required.nil? || !notation_required.any?(true)
-      if @piece_type == "P" 
-        if ( @board[@dest_y][@dest_x] || @en_passant )
-          return NotationParser.encode_notation(@orig)[0]
-        else
-          return ''
-        end
+    if notation_required.nil? || notation_required.none?(true)
+      if @piece_type == 'P'
+        return NotationParser.encode_notation(@orig)[0] if @board[@dest_y][@dest_x] || @en_passant
+
+        return ''
       end
       return @piece_type
     end
     ambiguous_encoded = @piece_type
-    encoded_origin_chars  = NotationParser.encode_notation(@orig).chars
+    encoded_origin_chars = NotationParser.encode_notation(@orig).chars
     notation_required.each_with_index do |value, i|
       ambiguous_encoded += encoded_origin_chars[i] if value
     end

--- a/lib/helpers/logger.rb
+++ b/lib/helpers/logger.rb
@@ -5,7 +5,7 @@ require 'chessmate'
 require 'pry'
 
 class Logger
-  def initialize(orig, dest, board, en_passant = false)
+  def initialize(orig, dest, board, en_passant: false, promotion_type: nil)
     @orig = orig
     @dest = dest
     @board = board
@@ -17,6 +17,8 @@ class Logger
     @piece = @board[@orig_y][@orig_x]
 
     @piece_color, @piece_type = @piece.chars
+
+    @promotion_type = promotion_type
   end
 
   def log_move
@@ -28,7 +30,7 @@ class Logger
     capture = @board[@dest_y][@dest_x] || @en_passant ? 'x' : ''
     destination = NotationParser.encode_notation(@dest)
 
-    origin + capture + destination
+    origin + capture + destination + promotion(@promotion_type) + check_or_mate
   end
 
   private
@@ -65,5 +67,26 @@ class Logger
       ambiguous_encoded += encoded_origin_chars[i] if value
     end
     ambiguous_encoded
+  end
+
+  def check_or_mate
+    game = ChessMate.new(board: @board, ignore_logging: true)
+    encoded_orig = NotationParser.encode_notation(@orig)
+    encoded_dest = NotationParser.encode_notation(@dest)
+    opposite_color_letter = @piece_color == "W" ? "B" : "W"
+    opposite_color_string = opposite_color_letter == 'W' ? 'white' : 'black'
+
+    game.move(encoded_orig, encoded_dest)
+    checkmate = game.checkmate?(opposite_color_letter)
+    check = game.in_check?[opposite_color_string.to_sym]
+
+    return '#' if checkmate
+    return '+' if check
+    
+    ""
+  end
+
+  def promotion(promotion_type)
+    ''
   end
 end

--- a/lib/pieces/king.rb
+++ b/lib/pieces/king.rb
@@ -16,10 +16,8 @@ class King < Piece
   end
 
   def self.valid_castling_move?(orig, dest, board, castling)
-    orig_y = orig[0]
-    orig_x = orig[1]
-    dest_y = dest[0]
-    dest_x = dest[1]
+    orig_y, orig_x = orig
+    dest_y, dest_x = dest
 
     return false if orig_y != dest_y || (orig_x - dest_x).abs != 2
 

--- a/lib/pieces/pawn.rb
+++ b/lib/pieces/pawn.rb
@@ -6,10 +6,8 @@ class Pawn < Piece
   def self.move_is_valid?(orig, dest, board, en_passant)
     return true if en_passant(orig, dest, board, en_passant)
 
-    orig_y = orig[0]
-    orig_x = orig[1]
-    dest_y = dest[0]
-    dest_x = dest[1]
+    orig_y, orig_x = orig
+    dest_y, dest_x = dest
     piece_type = board[orig_y][orig_x]
     piece_color = piece_type[0].downcase
 
@@ -36,10 +34,8 @@ class Pawn < Piece
   end
 
   def self.en_passant(orig, dest, board, en_passant)
-    orig_y = orig[0]
-    orig_x = orig[1]
-    dest_y = dest[0]
-    dest_x = dest[1]
+    orig_y, orig_x = orig
+    dest_y, dest_x = dest
     piece_type = board[orig_y][orig_x]
     opposite_color = piece_type[0].downcase == 'w' ? :black : :white
     direction = opposite_color == :white ? -1 : 1

--- a/lib/pieces/piece.rb
+++ b/lib/pieces/piece.rb
@@ -2,10 +2,8 @@
 
 class Piece
   def self.obstructed?(orig, dest, board)
-    orig_y = orig[0]
-    orig_x = orig[1]
-    dest_y = dest[0]
-    dest_x = dest[1]
+    orig_y, orig_x = orig
+    dest_y, dest_x = dest
 
     if orig_y == dest_y
 
@@ -45,10 +43,8 @@ class Piece
   end
 
   def self.capturable?(orig, dest, board)
-    orig_y = orig[0]
-    orig_x = orig[1]
-    dest_y = dest[0]
-    dest_x = dest[1]
+    orig_y, orig_x = orig
+    dest_y, dest_x = dest
     orig_piece = board[orig_y][orig_x]
     dest_piece = board[dest_y][dest_x]
 

--- a/spec/chessmate_spec.rb
+++ b/spec/chessmate_spec.rb
@@ -59,7 +59,7 @@ describe ChessMate do
         chess = ChessMate.new
         expect(chess.board).to eql(DEFAULT[:board])
         expect(chess.turn).to eql(DEFAULT[:turn])
-        expect(chess.promotable).to eql(DEFAULT[:promotable])
+        expect(chess.promotable).to eql(false)
         expect(chess.en_passant).to eql(DEFAULT[:en_passant])
         expect(chess.castling).to eql(DEFAULT[:castling])
         expect(chess.in_check).to eql(DEFAULT[:in_check])
@@ -1357,32 +1357,32 @@ describe ChessMate do
   end
 
   describe 'promote? method' do
-    it 'should return true if white piece is on last rank' do
+    it 'should return true if white piece is moving to last rank' do
       board = Array.new(8) { Array.new(8, nil) }
-      board[0][0] = 'WP'
+      board[1][0] = 'WP'
       chess = ChessMate.new(board: board)
-      expect(chess.promote?([0, 0])).to eql(true)
+      expect(chess.promote?([1, 0])).to eql(true)
     end
 
-    it 'should return true if black piece is on last rank' do
+    it 'should return true if black piece is moving to last rank' do
       board = Array.new(8) { Array.new(8, nil) }
-      board[7][0] = 'BP'
+      board[6][0] = 'BP'
       chess = ChessMate.new(board: board)
-      expect(chess.promote?([7, 0])).to eql(true)
+      expect(chess.promote?([6, 0])).to eql(true)
     end
 
     it 'should return false otherwise' do
       board = Array.new(8) { Array.new(8, nil) }
-      board[1][0] = 'WP'
-      board[6][0] = 'BP'
+      board[2][0] = 'WP'
+      board[5][0] = 'BP'
       chess = ChessMate.new(board: board)
-      expect(chess.promote?([1, 0])).to eql(false)
-      expect(chess.promote?([6, 0])).to eql(false)
+      expect(chess.promote?([2, 0])).to eql(false)
+      expect(chess.promote?([5, 0])).to eql(false)
     end
   end
 
   describe 'promote! method' do
-    it 'should return nil if piece cannot promote' do
+    it 'should return nil if piece cannot promote'do
       board = Array.new(8) { Array.new(8, nil) }
       board[1][0] = 'WP'
       chess = ChessMate.new(board: board)
@@ -1399,8 +1399,9 @@ describe ChessMate do
     context 'should promote to' do
       before :each do
         board = Array.new(8) { Array.new(8, nil) }
-        board[0][0] = 'WP'
+        board[1][0] = 'WP'
         @chess = ChessMate.new(board: board)
+        @chess.move('a7','a8')
       end
 
       it 'queen' do

--- a/spec/chessmate_spec.rb
+++ b/spec/chessmate_spec.rb
@@ -1382,7 +1382,7 @@ describe ChessMate do
   end
 
   describe 'promote! method' do
-    it 'should return nil if piece cannot promote'do
+    it 'should return nil if piece cannot promote' do
       board = Array.new(8) { Array.new(8, nil) }
       board[1][0] = 'WP'
       chess = ChessMate.new(board: board)
@@ -1401,7 +1401,7 @@ describe ChessMate do
         board = Array.new(8) { Array.new(8, nil) }
         board[1][0] = 'WP'
         @chess = ChessMate.new(board: board)
-        @chess.move('a7','a8')
+        @chess.move('a7', 'a8')
       end
 
       it 'queen' do

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -37,6 +37,17 @@ describe 'Logger' do
       [nil, nil, nil, nil, nil, nil, nil, nil],
       ['WR', nil, nil, nil, nil, nil, nil, 'WQ']
     ]
+
+    @specialty_moves_board = [
+      [nil, nil, nil, nil, nil, nil, nil, nil],
+      ['WP', nil, nil, nil, nil, nil, nil, nil],
+      [nil, nil, nil, nil, nil, nil, nil, nil],
+      [nil, nil, nil, nil, nil, nil, nil, nil],
+      [nil, nil, nil, nil, nil, nil, nil, nil],
+      [nil, nil, nil, nil, nil, nil, nil, nil],
+      [nil, nil, nil, nil, nil, nil, nil, nil],
+      ['WR', nil, nil, nil, 'WK', nil, nil, 'WR']
+    ]
   end
 
   context 'pawn moves' do
@@ -48,6 +59,11 @@ describe 'Logger' do
     it 'should log capturing moves' do
       logger = Logger.new([6, 0], [5, 1], @capture_moves_board)
       expect(logger.log_move).to eql('axb3')
+    end
+
+    it 'should log en passant moves' do
+      logger = Logger.new([3, 6], [2, 7], @capture_moves_board, true)
+      expect(logger.log_move).to eql('gxh6')
     end
   end
 
@@ -118,6 +134,21 @@ describe 'Logger' do
     it 'should handle knights/bishops/queens with ability to move to dest square' do
       logger = Logger.new([2, 3], [0, 1], @ambiguous_moves_board)
       expect(logger.log_move).to eql('Bdb8')
+    end
+  end
+
+  context 'specialty moves' do
+    it 'should log kingside castles' do
+      logger = Logger.new([7, 4], [7, 6], @specialty_moves_board)
+      expect(logger.log_move).to eql('0-0')
+    end
+
+    it 'should log queenside castles' do
+      logger = Logger.new([7, 4], [7, 2], @specialty_moves_board)
+      expect(logger.log_move).to eql('0-0-0')
+    end
+
+    it 'should log pawn promotion' do
     end
   end
 end

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -106,8 +106,8 @@ describe 'Logger' do
     end
 
     it 'should add rank info to log moves with pieces in same rank' do
-      logger = Logger.new([7, 0], [5, 0], @ambiguous_moves_board)
-      expect(logger.log_move).to eql('R1a3')
+      logger = Logger.new([0, 3], [0, 5], @ambiguous_moves_board)
+      expect(logger.log_move).to eql('Rdf8')
     end
 
     it 'should add file and rank info to log moves with multiple pieces in same file and rank' do

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -5,17 +5,6 @@ require_relative '../lib/helpers/logger'
 
 describe 'Logger' do
   before :each do
-    @odd_moves_board = [
-      [nil, nil, nil, 'BR', nil, nil, nil, 'BR'],
-      ['BB', nil, nil, nil, nil, nil, nil, nil],
-      [nil, nil, nil, 'BB', nil, nil, nil, nil],
-      ['WR', nil, nil, nil, nil, nil, nil, nil],
-      [nil, nil, nil, nil, 'WQ', nil, nil, 'WQ'],
-      [nil, nil, nil, nil, nil, nil, nil, nil],
-      [nil, nil, nil, nil, nil, nil, nil, nil],
-      ['WR', nil, nil, nil, nil, nil, nil, 'WQ']
-    ]
-
     @normal_moves_board = [
       [nil, nil, nil, nil, nil, nil, nil, nil],
       [nil, nil, nil, nil, nil, nil, nil, nil],
@@ -36,8 +25,20 @@ describe 'Logger' do
       [nil, 'BP', nil, 'BP', nil, nil, nil, nil],
       ['WP', 'WN', 'WB', 'WQ', 'WK', nil, nil, nil],
       [nil, nil, nil, nil, nil, nil, nil, nil]
+		]
+		
+		@ambiguous_moves_board = [
+      [nil, nil, nil, 'BR', nil, nil, nil, 'BR'],
+      ['BB', nil, nil, nil, nil, nil, nil, nil],
+      [nil, nil, nil, 'BB', nil, nil, nil, nil],
+      ['WR', nil, nil, nil, nil, nil, nil, nil],
+      [nil, nil, nil, nil, 'WQ', nil, nil, 'WQ'],
+      [nil, nil, nil, nil, nil, nil, nil, nil],
+      [nil, nil, nil, nil, nil, nil, nil, nil],
+      ['WR', nil, nil, nil, nil, nil, nil, 'WQ']
     ]
-  end
+	end
+	
   context 'pawn moves' do
     it 'should log normal pawn moves' do
       logger = Logger.new([6, 0], [5, 0], @normal_moves_board)
@@ -96,5 +97,27 @@ describe 'Logger' do
       logger = Logger.new([6, 4], [5, 3], @capture_moves_board)
       expect(logger.log_move).to eql('Kxd3')
     end
-  end
+	end
+	
+	context 'ambiguous moves' do
+		it 'should add file info to log moves with pieces in same file' do
+			logger = Logger.new([7, 0], [5, 0], @ambiguous_moves_board)
+			expect(logger.log_move).to eql('R1a3')
+		end
+
+		it 'should add rank info to log moves with pieces in same rank' do
+			logger = Logger.new([7, 0], [5, 0], @ambiguous_moves_board)
+			expect(logger.log_move).to eql('R1a3')
+		end
+
+		it 'should add file and rank info to log moves with multiple pieces in same file and rank' do
+			logger = Logger.new([4, 7], [7, 4], @ambiguous_moves_board)
+			expect(logger.log_move).to eql('Qh4e1')
+		end
+
+		it 'should handle knights/bishops/queens with ability to move to dest square' do
+			logger = Logger.new([2, 3], [0, 1], @ambiguous_moves_board)
+			expect(logger.log_move).to eql('Bdb8')
+		end
+	end
 end

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require_relative '../lib/helpers/logger'
+require 'chessmate'
 
 describe 'Logger' do
   before :each do
@@ -161,11 +162,9 @@ describe 'Logger' do
     end
 
 		it 'should log pawn promotion' do
-			%w[rook knight bishop queen].each do |piece|
-				board = @specialty_moves_board.map(&:dup)
-				logger = Logger.new([1, 0], [0, 0], board)
-				piece_type = %w[rook bishop queen].include?(piece) ? piece[0].upcase : 'N'
-				expect(logger.log_move).to eql("a8=(#{piece_type})")
+			%w[R N B Q].each do |piece|
+				logger = Logger.new(nil, nil, nil, promotion_type: piece)
+				expect(logger.log_promotion).to eql("=(#{piece})")
 			end
     end
 	end

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -48,9 +48,9 @@ describe 'Logger' do
       [nil, nil, nil, nil, nil, nil, nil, nil],
       [nil, nil, nil, nil, nil, nil, nil, nil],
       ['WR', nil, nil, nil, 'WK', nil, nil, 'WR']
-		]
-		
-		@check_board = [
+    ]
+
+    @check_board = [
       [nil, nil, nil, 'BQ', nil, nil, nil, nil],
       [nil, nil, nil, nil, nil, nil, nil, nil],
       [nil, nil, nil, nil, nil, nil, nil, nil],
@@ -59,8 +59,7 @@ describe 'Logger' do
       ['BN', nil, nil, nil, nil, nil, nil, nil],
       [nil, nil, nil, 'WP', nil, 'WP', nil, nil],
       [nil, nil, nil, 'WR', 'WK', 'WR', nil, nil]
-		]
-		
+    ]
   end
 
   context 'pawn moves' do
@@ -161,23 +160,23 @@ describe 'Logger' do
       expect(logger.log_move).to eql('0-0-0')
     end
 
-		it 'should log pawn promotion' do
-			%w[R N B Q].each do |piece|
-				logger = Logger.new(nil, nil, nil, promotion_type: piece)
-				expect(logger.log_promotion).to eql("=(#{piece})")
-			end
+    it 'should log pawn promotion' do
+      %w[R N B Q].each do |piece|
+        logger = Logger.new(nil, nil, nil, promotion_type: piece)
+        expect(logger.log_promotion).to eql("=(#{piece})")
+      end
     end
-	end
-	
-	context 'game status indications' do
-		 it 'should log check' do
-			logger = Logger.new([5, 0], [6, 2], @check_board)
-      expect(logger.log_move).to eql('Nc2+')
-		 end
+  end
 
-		 it 'should log checkmate' do
-			logger = Logger.new([0, 3], [0, 4], @check_board)
+  context 'game status indications' do
+    it 'should log check' do
+      logger = Logger.new([5, 0], [6, 2], @check_board)
+      expect(logger.log_move).to eql('Nc2+')
+    end
+
+    it 'should log checkmate' do
+      logger = Logger.new([0, 3], [0, 4], @check_board)
       expect(logger.log_move).to eql('Qe8#')
-		 end
-	end
+    end
+  end
 end

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../lib/helpers/logger'
+
+describe 'Logger' do
+  before :each do
+    @odd_moves_board = [
+      [nil, nil, nil, 'BR', nil, nil, nil, 'BR'],
+      ['BB', nil, nil, nil, nil, nil, nil, nil],
+      [nil, nil, nil, 'BB', nil, nil, nil, nil],
+      ['WR', nil, nil, nil, nil, nil, nil, nil],
+      [nil, nil, nil, nil, 'WQ', nil, nil, 'WQ'],
+      [nil, nil, nil, nil, nil, nil, nil, nil],
+      [nil, nil, nil, nil, nil, nil, nil, nil],
+      ['WR', nil, nil, nil, nil, nil, nil, 'WQ']
+    ]
+
+    @normal_moves_board = [
+      [nil, nil, nil, nil, nil, nil, nil, nil],
+      [nil, nil, nil, nil, nil, nil, nil, nil],
+      [nil, nil, nil, nil, nil, nil, nil, nil],
+      [nil, nil, nil, nil, nil, nil, nil, nil],
+      [nil, nil, nil, nil, nil, nil, nil, nil],
+      [nil, nil, nil, nil, nil, nil, nil, nil],
+      ['WP', 'WN', 'WB', 'WQ', 'WK', nil, nil, nil],
+      [nil, nil, nil, nil, nil, nil, nil, nil]
+    ]
+
+    @capture_moves_board = [
+      [nil, nil, nil, nil, nil, nil, nil, nil],
+      [nil, nil, nil, nil, nil, nil, nil, nil],
+      [nil, nil, nil, nil, nil, nil, nil, nil],
+      [nil, nil, nil, nil, nil, nil, nil, nil],
+      ['BP', nil, nil, nil, nil, nil, nil, nil],
+      [nil, 'BP', nil, 'BP', nil, nil, nil, nil],
+      ['WP', 'WN', 'WB', 'WQ', 'WK', nil, nil, nil],
+      [nil, nil, nil, nil, nil, nil, nil, nil]
+    ]
+  end
+  context 'pawn moves' do
+    it 'should log normal pawn moves' do
+      logger = Logger.new([6, 0], [5, 0], @normal_moves_board)
+      expect(logger.log_move).to eql('a3')
+    end
+
+    it 'should log capturing moves' do
+      logger = Logger.new([6, 0], [5, 1], @capture_moves_board)
+      expect(logger.log_move).to eql('axb3')
+    end
+  end
+
+  context 'knight moves' do
+    it 'should log normal knight moves' do
+      logger = Logger.new([6, 1], [4, 0], @normal_moves_board)
+      expect(logger.log_move).to eql('Na4')
+    end
+
+    it 'should log capturing moves' do
+      logger = Logger.new([6, 1], [4, 0], @capture_moves_board)
+      expect(logger.log_move).to eql('Nxa4')
+    end
+  end
+
+  context 'bishop moves' do
+    it 'should log normal bishop moves' do
+      logger = Logger.new([6, 2], [5, 1], @normal_moves_board)
+      expect(logger.log_move).to eql('Bb3')
+    end
+
+    it 'should log capturing moves' do
+      logger = Logger.new([6, 2], [5, 1], @capture_moves_board)
+      expect(logger.log_move).to eql('Bxb3')
+    end
+  end
+
+  context 'queen moves' do
+    it 'should log normal queen moves' do
+      logger = Logger.new([6, 3], [5, 3], @normal_moves_board)
+      expect(logger.log_move).to eql('Qd3')
+    end
+
+    it 'should log capturing moves' do
+      logger = Logger.new([6, 3], [5, 3], @capture_moves_board)
+      expect(logger.log_move).to eql('Qxd3')
+    end
+  end
+
+  context 'king moves' do
+    it 'should log normal king moves' do
+      logger = Logger.new([6, 4], [5, 4], @normal_moves_board)
+      expect(logger.log_move).to eql('Ke3')
+    end
+
+    it 'should log capturing moves' do
+      logger = Logger.new([6, 4], [5, 3], @capture_moves_board)
+      expect(logger.log_move).to eql('Kxd3')
+    end
+  end
+end

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -20,14 +20,14 @@ describe 'Logger' do
       [nil, nil, nil, nil, nil, nil, nil, nil],
       [nil, nil, nil, nil, nil, nil, nil, nil],
       [nil, nil, nil, nil, nil, nil, nil, nil],
-      [nil, nil, nil, nil, nil, nil, nil, nil],
+      [nil, nil, nil, nil, nil, nil, 'WP', 'BP'],
       ['BP', nil, nil, nil, nil, nil, nil, nil],
       [nil, 'BP', nil, 'BP', nil, nil, nil, nil],
       ['WP', 'WN', 'WB', 'WQ', 'WK', nil, nil, nil],
       [nil, nil, nil, nil, nil, nil, nil, nil]
-		]
-		
-		@ambiguous_moves_board = [
+    ]
+
+    @ambiguous_moves_board = [
       [nil, nil, nil, 'BR', nil, nil, nil, 'BR'],
       ['BB', nil, nil, nil, nil, nil, nil, nil],
       [nil, nil, nil, 'BB', nil, nil, nil, nil],
@@ -37,8 +37,8 @@ describe 'Logger' do
       [nil, nil, nil, nil, nil, nil, nil, nil],
       ['WR', nil, nil, nil, nil, nil, nil, 'WQ']
     ]
-	end
-	
+  end
+
   context 'pawn moves' do
     it 'should log normal pawn moves' do
       logger = Logger.new([6, 0], [5, 0], @normal_moves_board)
@@ -97,27 +97,27 @@ describe 'Logger' do
       logger = Logger.new([6, 4], [5, 3], @capture_moves_board)
       expect(logger.log_move).to eql('Kxd3')
     end
-	end
-	
-	context 'ambiguous moves' do
-		it 'should add file info to log moves with pieces in same file' do
-			logger = Logger.new([7, 0], [5, 0], @ambiguous_moves_board)
-			expect(logger.log_move).to eql('R1a3')
-		end
+  end
 
-		it 'should add rank info to log moves with pieces in same rank' do
-			logger = Logger.new([7, 0], [5, 0], @ambiguous_moves_board)
-			expect(logger.log_move).to eql('R1a3')
-		end
+  context 'ambiguous moves' do
+    it 'should add file info to log moves with pieces in same file' do
+      logger = Logger.new([7, 0], [5, 0], @ambiguous_moves_board)
+      expect(logger.log_move).to eql('R1a3')
+    end
 
-		it 'should add file and rank info to log moves with multiple pieces in same file and rank' do
-			logger = Logger.new([4, 7], [7, 4], @ambiguous_moves_board)
-			expect(logger.log_move).to eql('Qh4e1')
-		end
+    it 'should add rank info to log moves with pieces in same rank' do
+      logger = Logger.new([7, 0], [5, 0], @ambiguous_moves_board)
+      expect(logger.log_move).to eql('R1a3')
+    end
 
-		it 'should handle knights/bishops/queens with ability to move to dest square' do
-			logger = Logger.new([2, 3], [0, 1], @ambiguous_moves_board)
-			expect(logger.log_move).to eql('Bdb8')
-		end
-	end
+    it 'should add file and rank info to log moves with multiple pieces in same file and rank' do
+      logger = Logger.new([4, 7], [7, 4], @ambiguous_moves_board)
+      expect(logger.log_move).to eql('Qh4e1')
+    end
+
+    it 'should handle knights/bishops/queens with ability to move to dest square' do
+      logger = Logger.new([2, 3], [0, 1], @ambiguous_moves_board)
+      expect(logger.log_move).to eql('Bdb8')
+    end
+  end
 end

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -47,7 +47,19 @@ describe 'Logger' do
       [nil, nil, nil, nil, nil, nil, nil, nil],
       [nil, nil, nil, nil, nil, nil, nil, nil],
       ['WR', nil, nil, nil, 'WK', nil, nil, 'WR']
-    ]
+		]
+		
+		@check_board = [
+      [nil, nil, nil, 'BQ', nil, nil, nil, nil],
+      [nil, nil, nil, nil, nil, nil, nil, nil],
+      [nil, nil, nil, nil, nil, nil, nil, nil],
+      [nil, nil, nil, nil, nil, nil, nil, nil],
+      [nil, nil, nil, nil, nil, nil, nil, nil],
+      ['BN', nil, nil, nil, nil, nil, nil, nil],
+      [nil, nil, nil, 'WP', nil, 'WP', nil, nil],
+      [nil, nil, nil, 'WR', 'WK', 'WR', nil, nil]
+		]
+		
   end
 
   context 'pawn moves' do
@@ -62,7 +74,7 @@ describe 'Logger' do
     end
 
     it 'should log en passant moves' do
-      logger = Logger.new([3, 6], [2, 7], @capture_moves_board, true)
+      logger = Logger.new([3, 6], [2, 7], @capture_moves_board, en_passant: true)
       expect(logger.log_move).to eql('gxh6')
     end
   end
@@ -148,7 +160,25 @@ describe 'Logger' do
       expect(logger.log_move).to eql('0-0-0')
     end
 
-    it 'should log pawn promotion' do
+		it 'should log pawn promotion' do
+			%w[rook knight bishop queen].each do |piece|
+				board = @specialty_moves_board.map(&:dup)
+				logger = Logger.new([1, 0], [0, 0], board)
+				piece_type = %w[rook bishop queen].include?(piece) ? piece[0].upcase : 'N'
+				expect(logger.log_move).to eql("a8=(#{piece_type})")
+			end
     end
-  end
+	end
+	
+	context 'game status indications' do
+		 it 'should log check' do
+			logger = Logger.new([5, 0], [6, 2], @check_board)
+      expect(logger.log_move).to eql('Nc2+')
+		 end
+
+		 it 'should log checkmate' do
+			logger = Logger.new([0, 3], [0, 4], @check_board)
+      expect(logger.log_move).to eql('Qe8#')
+		 end
+	end
 end


### PR DESCRIPTION
Adds notation capabilities to ChessMate.

Current limitations include potential incorrect notation for pawn promotion moves since it only logs that a promotion happened. Will update in a later PR and bump version before pushing to RubyGems.